### PR TITLE
dbuteau

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ job.show_notification = "false"
 
 jobId = manager.addJob(job)
 
+#updating/replace the job
+job.id = jobId
+job.show_notification = "true"
+manager.updateJob(job)
+
 #delete the previously defined job
 manager.deleteJob(jobId)
 

--- a/resources/lib/cron.py
+++ b/resources/lib/cron.py
@@ -41,18 +41,20 @@ class CronManager:
 
         if(job.id >= 0):
             #replace existing job
-            self.jobs[job.id] = job
+            indices = [i for i, x in enumerate(self.jobs) if x.id == str(job.id)]
+            self.jobs[indices[0]] = job
+
         else:
             # check if expression and command already exist no need to define it twice
             if self._exist(job):
                 xbmc.executebuiltin('Notification(Job Already exist, doing nothing)')
                 xbmc.log('[service.cronxbmc] Job already exist, doing nothing', xbmc.LOGWARNING)
-                return False
+                return job.id
             #calcul the new job.id
             job.id = self._getLastId()+1
             #add a new job
             self.jobs.append(job)
-            
+        
         #write the file
         self._writeCronFile()
         return job.id
@@ -68,7 +70,7 @@ class CronManager:
         lJobs = self.getJobs(True)
         nbRows = len(lJobs)
         if nbRows > 0:
-            return int(lJobs[nbRows].id)-1
+            return int(lJobs[nbRows-1].id)
         else:
             return 0
 
@@ -153,7 +155,7 @@ class CronManager:
                 else:
                     tempJob.addon = utils.__addon_id__
                 
-                xbmc.log(tempJob.name + " " + tempJob.expression + " loaded",xbmc.LOGDEBUG)
+                xbmc.log('[service.cronxbmc]'+tempJob.name + " " + tempJob.expression + " loaded",xbmc.LOGDEBUG)
                 adv_jobs.append(tempJob)
 
         except IOError:

--- a/resources/lib/cron.py
+++ b/resources/lib/cron.py
@@ -30,20 +30,16 @@ class CronManager:
             croniter(job.expression)
         except:
             #didn't work
-            return False
+            raise ValueError('Wrong expression')
 
         #set the addon id if there isn't one
         if(job.addon == None):
             job.addon = utils.addon_id()
         
         self._refreshJobs()
-        
 
         if(job.id >= 0):
-            #replace existing job
-            indices = [i for i, x in enumerate(self.jobs) if x.id == str(job.id)]
-            self.jobs[indices[0]] = job
-
+            raise ValueError('job.id should be -1')
         else:
             # check if expression and command already exist no need to define it twice
             if self._exist(job):
@@ -58,6 +54,32 @@ class CronManager:
         #write the file
         self._writeCronFile()
         return job.id
+
+    def updateJob(self,job):
+        try:
+            #verify the cron expression here, throws ValueError if wrong
+            croniter(job.expression)
+        except:
+            raise ValueError('Wrong expression')
+
+        #set the addon id if there isn't one
+        if(job.addon == None):
+            job.addon = utils.addon_id()
+
+        self._refreshJobs()
+
+        if(job.id >= 0):
+            #replace existing job
+            indices = [i for i, x in enumerate(self.jobs) if x.id == str(job.id)]
+            self.jobs[indices[0]] = job
+        else:
+            raise ValueError('Must provide target job.id')
+
+        #write the file
+        self._writeCronFile()
+        return job.id
+
+
     
     #check if another addon has already defined exactly the same job but with another id/name
     def _exist(self,job):

--- a/resources/lib/cron.py
+++ b/resources/lib/cron.py
@@ -48,7 +48,7 @@ class CronManager:
         #write the file
         self._writeCronFile()
 
-        return True
+        return self.jobs[job.id]
     
     def deleteJob(self,jId):
         self._refreshJobs()
@@ -105,7 +105,7 @@ class CronManager:
         stat_file = xbmcvfs.Stat(xbmc.translatePath(self.CRONFILE))
         
         if(stat_file.st_mtime() > self.last_read):
-            utils.log("File update, loading new jobs",xbmc.LOGDEBUG)
+            xbmc.log("File update, loading new jobs",xbmc.LOGDEBUG)
             #update the file
             self.jobs = self._readCronFile();
             self.last_read = time.time()
@@ -132,7 +132,7 @@ class CronManager:
                 else:
                     tempJob.addon = utils.__addon_id__
                 
-                utils.log(tempJob.name + " " + tempJob.expression + " loaded",xbmc.LOGDEBUG)
+                xbmc.log(tempJob.name + " " + tempJob.expression + " loaded",xbmc.LOGDEBUG)
                 adv_jobs.append(tempJob)
 
         except IOError:
@@ -174,7 +174,7 @@ class CronManager:
             f.close()
                                         
         except IOError:
-            utils.log("error writing cron file",xbmc.LOGERROR)
+            xbmc.log("error writing cron file",xbmc.LOGERROR)
 
 class CronService:
     last_check = -1
@@ -206,13 +206,13 @@ class CronService:
                     #if this command should run then run it
                     if(runTime <= now):
                         self.runJob(command)
-                        utils.log(command.name + " will run again on " + datetime.datetime.fromtimestamp(cron_exp.get_next(float)).strftime('%m-%d-%Y %H:%M'))
+                        xbmc.log(command.name + " will run again on " + datetime.datetime.fromtimestamp(cron_exp.get_next(float)).strftime('%m-%d-%Y %H:%M'))
                 
             if(monitor.waitForAbort(10)):
                 break;
 
     def runJob(self,cronJob,override_notification = False):
-        utils.log("running command " + cronJob.name + " for addon " + cronJob.addon)
+        xbmc.log("running command " + cronJob.name + " for addon " + cronJob.addon)
 
         if(cronJob.show_notification == "true" or override_notification):
             #show a notification that this command is running

--- a/service.py
+++ b/service.py
@@ -2,5 +2,5 @@ import resources.lib.utils as utils
 from resources.lib.cron import CronService
 
 #run the program
-utils.log("Cron for Kodi service starting....")
+xbmc.log("Cron for Kodi service starting....",xbmc.LOGINFO)
 CronService().runProgram()


### PR DESCRIPTION
Made lot of improvement, don't know if you're interested in. Feel free to merge or refuse: 

- AddJob now return the job.id created: (ease later use for addon, they can memorize/keep the id in their config)
- Anchor the job.id: the id is wrote in the cron.xml now (need by above, the id must not change anymore addons count on it )
- add updateJob method: addons can now update/replace their own previously created cron
- on addJob method: check if expression + command is already in job list, if yes does not add the cron. Avoid filling xml with exactly same cron (for example if two differents addon add same command and same expressions, or if an addon add cron each time it's launched without checking if already launched/created). Because i think having 10+ same cron, launching same command in same time is resources-consuming (furthermore xml & ui is uselessly filled)
- stop using `utils.log` use `xbmc.log` in place

Seems to work fine on my kodi